### PR TITLE
Update to tantivy 0.11.2 and avoid blocking on merge while the

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,6 @@ rand = "0.7.2"
 router = "0.6.0"
 serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0.42"
-tantivy = "0.10.3"
+tantivy = "0.11.2"
 urlencoded = "0.6.0"
+async-std = "1.3"


### PR DESCRIPTION
Update to tantivy 0.11.2 and avoid blocking on merge while the IndexWriter's lock is held.